### PR TITLE
Childe rq polar star 2s

### DIFF
--- a/templates/childe-vape-rq-polar2s.json
+++ b/templates/childe-vape-rq-polar2s.json
@@ -15,7 +15,7 @@
         "reactionMode": "hydro_vaporize",
         "conditional": {
           "PolarStar": {
-            "GoldenMajesty": "2"
+            "GoldenMajesty": "3"
           }
         },
         "bonusStats": {

--- a/templates/childe-vape-rq-polar2s.json
+++ b/templates/childe-vape-rq-polar2s.json
@@ -1,0 +1,103 @@
+{
+  "templateName": "childe-vape-rq-polar2s",
+  "char": "Tartaglia",
+  "template": {
+    "format": "GOOD",
+    "dbVersion": 15,
+    "source": "Genshin Optimizer",
+    "version": 1,
+    "characters": [
+      {
+        "key": "Tartaglia",
+        "level": 90,
+        "ascension": 6,
+        "hitMode": "avgHit",
+        "reactionMode": "hydro_vaporize",
+        "conditional": {
+          "PolarStar": {
+            "GoldenMajesty": "2"
+          }
+        },
+        "bonusStats": {
+          "atk": 1000,
+          "atk_": 45,
+          "hydro_enemyRes_": -40
+        },
+        "enemyOverride": {},
+        "talent": {
+          "auto": 6,
+          "skill": 9,
+          "burst": 10
+        },
+        "infusionAura": "",
+        "constellation": 0,
+        "buildSettings": {
+          "setFilters": [
+            {
+              "key": "",
+              "num": 0
+            },
+            {
+              "key": "",
+              "num": 0
+            },
+            {
+              "key": "",
+              "num": 0
+            }
+          ],
+          "statFilters": {},
+          "mainStatKeys": {
+            "sands": [
+              "atk_",
+              "eleMas",
+              "enerRech_"
+            ],
+            "goblet": [
+              "atk_",
+              "eleMas",
+              "hydro_dmg_"
+            ],
+            "circlet": [
+              "eleMas",
+              "critDMG_",
+              "critRate_",
+              "atk_"
+            ]
+          },
+          "optimizationTarget": [
+            "burst",
+            "rangedDmg"
+          ],
+          "mainStatAssumptionLevel": 0,
+          "useExcludedArts": false,
+          "useEquippedArts": false,
+          "builds": [],
+          "buildDate": 0,
+          "maxBuildsToShow": 1,
+          "plotBase": "enerRech_",
+          "compareBuild": true,
+          "levelLow": 0,
+          "levelHigh": 20
+        },
+        "team": [
+          "Xiangling",
+          "Sucrose",
+          "Bennett"
+        ],
+        "compareData": false,
+        "favorite": false
+      }
+    ],
+    "weapons": [
+      {
+        "key": "PolarStar",
+        "level": 90,
+        "ascension": 6,
+        "refinement": 1,
+        "location": "Tartaglia",
+        "lock": true
+      }
+    ]
+  }
+}

--- a/templates/childe-vape-rq-polar2s.json
+++ b/templates/childe-vape-rq-polar2s.json
@@ -25,8 +25,8 @@
         },
         "enemyOverride": {},
         "talent": {
-          "auto": 6,
-          "skill": 9,
+          "auto": 10,
+          "skill": 10,
           "burst": 10
         },
         "infusionAura": "",
@@ -81,9 +81,9 @@
           "levelHigh": 20
         },
         "team": [
-          "Xiangling",
-          "Sucrose",
-          "Bennett"
+          "",
+          "",
+          ""
         ],
         "compareData": false,
         "favorite": false


### PR DESCRIPTION
added new template to calculate childe rq damage, with polar star 3 stacks, assuming 4NO and pyro res buffs